### PR TITLE
Add catch and reject for the `handler` promise 

### DIFF
--- a/test.js
+++ b/test.js
@@ -8,6 +8,7 @@ const tests = [
   'deadlock',
   'recursive-deadlock',
   'thread-main',
+  'handler-throw-error',
 ];
 
 (async () => {

--- a/test/handler-throw-error.js
+++ b/test/handler-throw-error.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const assert = require('assert').strict;
+
+const { locks } = require('..');
+
+module.exports = async () => {
+  assert.rejects(
+    async () => {
+      await locks.request('A', async () => {
+        throw new Error('test');
+      });
+    },
+    { message: 'test' }
+  );
+};

--- a/web-locks.js
+++ b/web-locks.js
@@ -23,8 +23,8 @@ class Lock {
   }
 
   enter(handler) {
-    return new Promise((resolve) => {
-      this.queue.push({ handler, resolve });
+    return new Promise((resolve, reject) => {
+      this.queue.push({ handler, resolve, reject });
       this.trying = true;
       setTimeout(() => {
         this.tryEnter();
@@ -38,11 +38,16 @@ class Lock {
     if (prev === LOCKED) return;
     this.owner = true;
     this.trying = false;
-    const { handler, resolve } = this.queue.shift();
-    handler(this).finally(() => {
-      this.leave();
-      resolve();
-    });
+    const { handler, resolve, reject } = this.queue.shift();
+    handler(this)
+      .then(() => {
+        this.leave();
+        resolve();
+      })
+      .catch((error) => {
+        this.leave();
+        reject(error);
+      });
   }
 
   leave() {


### PR DESCRIPTION
Added catch and reject for the `handler` promise (Issue #54).

Now, on client side we can catch and handle error thrown by the `handler` (the browser has the same behavior).
Example:
```
try {
  await locks.request('something', async () => {
    throw new Error('Test');
  });
} catch (error) {
  console.error(error);
}
```
(
- [x] tests and linter show no problems (`npm test`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
